### PR TITLE
Add example for extracting text from MesagesResponseBody

### DIFF
--- a/examples/create_a_message.rs
+++ b/examples/create_a_message.rs
@@ -10,10 +10,14 @@
 //! ```
 
 use clust::messages::ClaudeModel;
+use clust::messages::Content;
+use clust::messages::ContentBlock;
 use clust::messages::MaxTokens;
 use clust::messages::Message;
 use clust::messages::MessagesRequestBody;
+use clust::messages::MessagesResponseBody;
 use clust::messages::SystemPrompt;
+use clust::messages::TextContentBlock;
 use clust::Client;
 
 use clap::Parser;
@@ -24,6 +28,23 @@ struct Arguments {
     prompt: String,
     #[arg(short, long)]
     message: String,
+}
+
+/// Demonstrates how to extract the response text from a MessagesResponseBody, and prints to stdout
+fn print_response_text(response: MessagesResponseBody) {
+  match response.content {
+    Content::MultipleBlock(response_vector) => {
+      if !response_vector.is_empty() {
+        for block in response_vector.iter() {
+          match block {
+            ContentBlock::Text(TextContentBlock { _type, text }) => println!("Multi-block response text: {text}"),
+            _ => ()
+          };
+        }
+      }
+    },
+    Content::SingleText(text) => println!("Single text response: {text}")
+  };
 }
 
 #[tokio::main]
@@ -54,7 +75,9 @@ async fn main() -> anyhow::Result<()> {
         .create_a_message(request_body)
         .await?;
 
-    println!("Result:\n{}", response);
+    println!("Entire result:\n{}", response);
+
+    print_response_text(response);
 
     Ok(())
 }


### PR DESCRIPTION
Adds some code to the `create_a_message` example to demonstrate how to extract the actual response text from the `MessagesResponseBody` and its `Content::MultipleBlock` content field.

I was also thinking that it might be nice to have a simple text extractor function within `MessagesResponseBody` which returns something like a `Result<String, Err>` like body.content.text, which returns the text from either the `SingleText` or first `MultipleBlock` if it exists (and the number of `ContentBlocks` is 1). 

What do you think?

```
  ~/code/m-clust ~>> git branch
    main
  * textblock_example
  ~/code/m-clust ~>> cargo run --example create_a_message -- -p hello -m hello
      Finished dev [unoptimized + debuginfo] target(s) in 0.24s
       Running `target/debug/examples/create_a_message -p hello -m hello`
  Entire result:
  {
    "id": "msg_013vikkX9jdN9sHnhphbQ7ZY",
    "type": "message",
    "role": "assistant",
    "content": [
      {
        "type": "text",
        "text": "Hello! How can I assist you today?"
      }
    ],
    "model": "claude-3-haiku-20240307",
    "stop_reason": "end_turn",
    "stop_sequence": null,
    "usage": {
      "input_tokens": 9,
      "output_tokens": 12
    }
  }
  Multi-block response text: Hello! How can I assist you today?
```