### PR TITLE
chore: include partial_json for streaming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ full = ["macros"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1.6.*"
+bytes = "1"
 reqwest = { version = "0.12.*", features = ["json", "stream"] }
 serde = { version = "1.0.*", features = ["derive"] }
 serde-json-fmt = "0.1.*"

--- a/examples/streaming_messages_tokio.rs
+++ b/examples/streaming_messages_tokio.rs
@@ -17,7 +17,7 @@ use clust::messages::MessagesRequestBody;
 use clust::messages::StreamOption;
 use clust::messages::SystemPrompt;
 use clust::Client;
-
+use clust::messages::ContentBlockDelta;
 use clap::Parser;
 use tokio_stream::StreamExt;
 
@@ -70,7 +70,9 @@ async fn main() -> anyhow::Result<()> {
                 println!("Chunk:\n{}", chunk);
                 match chunk {
                     | MessageChunk::ContentBlockDelta(content_block_delta) => {
-                        buffer.push_str(&content_block_delta.delta.text);
+                        if let ContentBlockDelta::TextDeltaContentBlock(delta) =  content_block_delta.delta {
+                            buffer.push_str(&delta.text);
+                        }
                     },
                     | _ => {},
                 }

--- a/examples/streaming_messages_tools.rs
+++ b/examples/streaming_messages_tools.rs
@@ -1,12 +1,12 @@
 //! This example demonstrates how to use the `streaming_messages` API with `futures_util` backend.
 //!
 //! ```shell
-//! $ cargo run --example streaming_messages -- -p <prompt> -m <message>
+//! $ cargo run --example streaming_messages_tools
 //! ```
 //!
 //! e.g.
 //! ```shell
-//! $ cargo run --example streaming_messages -- -p "You are a excellent AI assistant." -m "Where is the capital of Japan?"
+//! $ cargo run --example streaming_messages_tools
 //! ```
 
 use clust::messages::ClaudeModel;
@@ -17,6 +17,7 @@ use clust::messages::MessageChunk;
 use clust::messages::MessagesRequestBody;
 use clust::messages::StreamOption;
 use clust::messages::SystemPrompt;
+use clust::messages::ToolDefinition;
 use clust::Client;
 
 use clap::Parser;
@@ -32,34 +33,32 @@ struct Arguments {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // 0. Parse the command-line arguments.
-    let arguments = Arguments::parse();
-
     // 1. Create a new API client with the API key loaded from the environment variable: `ANTHROPIC_API_KEY`
     let client = Client::from_env()?;
-    // or specify the API key directly
-    // let client = Client::from_api_key(clust::ApiKey::new("your-api-key"));
-
     // 2. Create a request body with stream option.
     let model = ClaudeModel::Claude3Sonnet20240229;
-    let messages = vec![Message::user(
-        arguments.message,
-    )];
+    let messages = vec![Message::user("how is the temperature like")];
     let max_tokens = MaxTokens::new(1024, model)?;
-    let system_prompt = SystemPrompt::new(arguments.prompt);
+    let system_prompt = SystemPrompt::new("use get_weather tool and tell me the current weather");
     let request_body = MessagesRequestBody {
         model,
         messages,
         max_tokens,
         system: Some(system_prompt),
+        tools: Some(vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            description: Some("Gives back weather".to_string()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {}
+            }),
+        }]), // Specify tool definitions
         stream: Some(StreamOption::ReturnStream), // Enable streaming
         ..Default::default()
     };
 
     // 3. Call the API.
-    let mut stream = client
-        .create_a_message_stream(request_body)
-        .await?;
+    let mut stream = client.create_a_message_stream(request_body).await?;
 
     let mut buffer = String::new();
 
@@ -67,20 +66,20 @@ async fn main() -> anyhow::Result<()> {
     // NOTE: The `futures_util::StreamExt` run on the single thread.
     while let Some(chunk) = stream.next().await {
         match chunk {
-            | Ok(chunk) => {
+            Ok(chunk) => {
                 println!("Chunk:\n{}", chunk);
                 match chunk {
-                    | MessageChunk::ContentBlockDelta(content_block_delta) => {
+                    MessageChunk::ContentBlockDelta(content_block_delta) => {
                         if let ContentBlockDelta::TextDeltaContentBlock(delta) =  content_block_delta.delta {
                             buffer.push_str(&delta.text);
                         }
-                    },
-                    | _ => {},
+                    }
+                    _ => {}
                 }
-            },
-            | Err(error) => {
+            }
+            Err(error) => {
                 eprintln!("Chunk error:\n{:?}", error);
-            },
+            }
         }
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -43,6 +43,8 @@ pub use error::ToolCallError;
 pub use max_tokens::MaxTokens;
 pub use message::Message;
 pub use message_chunk::ContentBlockDeltaChunk;
+pub use message_chunk::ContentBlockDelta;
+pub use message_chunk::ContentBlockStart;
 pub use message_chunk::ContentBlockStartChunk;
 pub use message_chunk::ContentBlockStopChunk;
 pub use message_chunk::DeltaUsage;

--- a/src/messages/content.rs
+++ b/src/messages/content.rs
@@ -360,6 +360,8 @@ pub enum ContentType {
     ToolUse,
     /// tool_result
     ToolResult,
+    /// input_json_delta
+    InputJsonDelta
 }
 
 impl Default for ContentType {
@@ -389,6 +391,9 @@ impl Display for ContentType {
             | ContentType::ToolResult => {
                 write!(f, "tool_result")
             },
+            | ContentType::InputJsonDelta => {
+                  write!(f, "input_json_delta")
+            },
         }
     }
 }
@@ -399,7 +404,8 @@ impl_enum_string_serialization!(
     Image => "image",
     TextDelta => "text_delta",
     ToolUse => "tool_use",
-    ToolResult => "tool_result"
+    ToolResult => "tool_result",
+    InputJsonDelta => "input_json_delta"
 );
 
 /// The image content source.


### PR DESCRIPTION
Including additional types so streaming with tools is supported.
Reference: https://docs.anthropic.com/en/api/messages-streaming
```
event: content_block_start
data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
```